### PR TITLE
Fix react-controllables version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "url": "https://github.com/hzdg/react-controlfacades/issues"
   },
   "dependencies": {
-    "react-controllables": "^0.7.0"
+    "react-controllables": "^0.6.0"
   }
 }


### PR DESCRIPTION
react-controllables is not available in v0.7.0 on npm and cannot be pulled yet.
Wait until fix in original repository.
